### PR TITLE
Add support for Qt5.2.1+

### DIFF
--- a/src/toolview/vglogview.cpp
+++ b/src/toolview/vglogview.cpp
@@ -260,12 +260,12 @@ void TopStatusItem::updateStatus( QDomElement status )
    }
 
    // start count
-   ret = sscanf( start_time.toAscii().constData(), "%d:%d:%d:%d.%4d",
+   ret = sscanf( start_time.toLatin1().constData(), "%d:%d:%d:%d.%4d",
                  &sday, &shours, &smins, &ssecs, &smsecs );
 
    if ( ret == 5 ) {
       QString end_time = status.firstChildElement( "time" ).text();
-      ret = sscanf( end_time.toAscii().constData(), "%d:%d:%d:%d.%4d",
+      ret = sscanf( end_time.toLatin1().constData(), "%d:%d:%d:%d.%4d",
                     &eday, &ehours, &emins, &esecs, &emsecs );
 
       if ( ret == 5 ) {


### PR DESCRIPTION
Replace deprecated toAscii() method with new standard toLatin1() to fix this error:
toolview/vglogview.cpp: In member function ‘void TopStatusItem::updateStatus(QDomElement)’:
toolview/vglogview.cpp:263:29: error: ‘class QString’ has no member named ‘toAscii’
    ret = sscanf( start_time.toAscii().constData(), "%d:%d:%d:%d.%4d",
                             ^~~~~~~